### PR TITLE
1 dockerfile for obp api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ RUN cp /usr/src/OBP-API/obp-api/pom.xml /tmp/pom.xml # For Packaging a local rep
 WORKDIR /usr/src/OBP-API
 RUN cp obp-api/src/main/resources/props/test.default.props.template obp-api/src/main/resources/props/test.default.props
 RUN cp obp-api/src/main/resources/props/sample.props.template obp-api/src/main/resources/props/default.props
-RUN mvn install -pl .,obp-commons
-RUN mvn install -DskipTests -pl obp-api
+RUN --mount=type=cache,target=/root/.m2 mvn install -pl .,obp-commons
+RUN --mount=type=cache,target=/root/.m2 mvn install -DskipTests -pl obp-api
 
 FROM openjdk:8-jre-alpine
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM maven:3-jdk-8 as maven
+# Build the source using maven, source is copied from the 'repo' build.
+ADD . /usr/src/OBP-API
+RUN cp /usr/src/OBP-API/obp-api/pom.xml /tmp/pom.xml # For Packaging a local repository within the image
+WORKDIR /usr/src/OBP-API
+RUN cp obp-api/src/main/resources/props/test.default.props.template obp-api/src/main/resources/props/test.default.props
+RUN cp obp-api/src/main/resources/props/sample.props.template obp-api/src/main/resources/props/default.props
+RUN mvn install -pl .,obp-commons
+RUN mvn install -DskipTests -pl obp-api
+
+FROM openjdk:8-jre-alpine
+
+# Add user 
+RUN adduser -D obp
+
+# Download jetty
+RUN wget -O - https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/9.4.15.v20190215/jetty-distribution-9.4.15.v20190215.tar.gz | tar zx
+RUN mv jetty-distribution-* jetty
+
+# Copy OBP source code
+# Copy build artifact (.war file) into jetty from 'maven' stage.
+COPY --from=maven /usr/src/OBP-API/obp-api/target/obp-api-*.war jetty/webapps/ROOT.war
+
+WORKDIR jetty
+RUN chown -R  obp /jetty
+
+# Switch to the obp user (non root)
+USER obp
+
+# Starts jetty
+ENTRYPOINT ["java", "-jar", "start.jar"]


### PR DESCRIPTION
Ref #1 

Fix #1


- added Dockerfile
- Reduce container re-build time from 22mins -> 2 seconds (depending on cache expiry, Using `--mount=type=cache` )

```
time podman build -t obp-api .

...

real  22m55.899s
user  37m35.264s
sys  1m48.375s
```

Then rebuilds will be much faster:

```
time podman build -t obp-api .

...
real  0m2.746s
user  0m2.754s
sys  0m1.532s
```


Note if cache expires or a layer changes the build will be slower, but not the worst case;

```
time podman build -t obp-api .
...
real	6m31.714s
user	18m43.876s
sys	0m32.894s
```


If you do want to build with no cache:

```
time podman build --no-cache -t obp-api .

# long time
```